### PR TITLE
Fix test for scales 1.4.0 compatibility

### DIFF
--- a/inst/tinytest/test-scale_colour_prism.R
+++ b/inst/tinytest/test-scale_colour_prism.R
@@ -21,8 +21,8 @@ expect_silent(ggplotGrob(g2))
 p1 <- prism_colour_pal(palette = "colors")
 p2 <- prism_color_pal(palette = "colors")
 
-expect_equal(class(p1), "function")
-expect_equal(class(p2), "function")
+expect_true(is.function(p1))
+expect_true(is.function(p2))
 
 expect_equal(attr(p1, "max_n"), 20)
 expect_equal(attr(p2, "max_n"), 20)

--- a/inst/tinytest/test-scale_fill_prism.R
+++ b/inst/tinytest/test-scale_fill_prism.R
@@ -17,7 +17,7 @@ expect_silent(ggplotGrob(g))
 # test that prism_fill_pal has correct structure
 p1 <- prism_fill_pal(palette = "colors")
 
-expect_equal(class(p1), "function")
+expect_true(is.function(p1))
 
 expect_equal(attr(p1, "max_n"), 20)
 

--- a/inst/tinytest/test-scale_shape_prism.R
+++ b/inst/tinytest/test-scale_shape_prism.R
@@ -17,7 +17,7 @@ expect_silent(ggplotGrob(g))
 # test that prism_shape_pal has correct structure
 p1 <- prism_shape_pal(palette = "default")
 
-expect_equal(class(p1), "function")
+expect_true(is.function(p1))
 
 expect_equal(attr(p1, "max_n"), 9)
 


### PR DESCRIPTION
Hi Charlotte,

We've been preparing for a new release of the scales package and during a reverse dependency check it unearthed that the new release would break some test assumptions in ggprism. This PR adapts the tests that assume the class 'function', whereas some palettes now have additional classes. I presumed that `is.function()` is the relevant matter here.

Best wishes,
Teun