### PR TITLE
Compatibility ggplot2 4.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Depends:
     R (>= 3.2)
 Imports: 
     digest,
-    ggplot2 (>= 3.2.0),
+    ggplot2 (>= 3.4.0),
     glue,
     grid,
     gtable (>= 0.1.1),

--- a/R/add_pvalue.R
+++ b/R/add_pvalue.R
@@ -278,7 +278,10 @@ add_pvalue <- function(data,
 
     option[["data"]] <- data
 
-    option[["mapping"]] <- do.call(aes_string, mapping)
+    mapping <- lapply(mapping, function(x) {
+      str2lang(paste0(".data[['", x, "']]"))
+    })
+    option[["mapping"]] <- aes(!!!mapping)
 
     do.call(geom_bracket, option)
 

--- a/R/theme_prism.R
+++ b/R/theme_prism.R
@@ -58,10 +58,10 @@ theme_prism <- function(palette = "black_and_white", base_size = 14,
 
   t <- theme(
     # Base elements (to be inherited by other elements)
-    line = element_line(colour = colours["axisColor"], size = base_line_size,
+    line = element_line(colour = colours["axisColor"], linewidth = base_line_size,
                         linetype = 1, lineend = "square"),
     rect = element_rect(fill = "white", colour = colours["axisColor"],
-                        size = base_rect_size, linetype = 1),
+                        linewidth = base_rect_size, linetype = 1),
     text = element_text(family = base_family, face = base_fontface,
                         colour = colours["graphTitleColor"], size = base_size,
                         lineheight = 0.9, hjust = 0.5, vjust = 0.5, angle = 0,

--- a/R/theme_prism.R
+++ b/R/theme_prism.R
@@ -169,7 +169,7 @@ theme_prism <- function(palette = "black_and_white", base_size = 14,
     complete = TRUE
   )
 
-  parent <- ggprism::ggprism_data$themes[["all_null"]]
+  parent <- theme(!!!ggprism::ggprism_data$themes[["all_null"]])
   if (!"legend.text.align" %in% rlang::fn_fmls_names(theme)) {
     t$legend.text.align  <- parent$legend.text.align <- NULL
     t$legend.title.align <- parent$legend.title.align <- NULL

--- a/inst/tinytest/test-theme_prism.R
+++ b/inst/tinytest/test-theme_prism.R
@@ -7,7 +7,7 @@ p <- ggplot(ToothGrowth, aes(x = as.factor(dose), y = len)) +
 
 #### Tests ---------------------------------------------------------------------
 # test that theme_prism has correct class
-expect_equal(class(theme_prism()), c("theme", "gg"))
+expect_true(inherits(theme_prism(), c("theme", "ggplot2::theme")))
 
 # test that theme_prism defaults work
 g <- p + theme_prism()


### PR DESCRIPTION
Hi Charlotte,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The offending issue is adressed in 213893d, but I've taken the liberty to move away from deprecated functions and arguments as they have become more vocal in the new ggplot2 version.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun